### PR TITLE
[blog] article header

### DIFF
--- a/source/assets/css/style.css
+++ b/source/assets/css/style.css
@@ -215,7 +215,8 @@ h1, h2, .h2, h3 {
 }
 
 #blog h3 {
-    line-height: 3em;
+    line-height: 1.5em;
+    margin-bottom: 1em;
 }
 
 #article {


### PR DESCRIPTION
Removed gap in article header when viewing on small screens.

<img width="896" alt="screen shot 2016-12-06 at 20 57 13" src="https://cloud.githubusercontent.com/assets/1255989/20941460/b0062516-bbf6-11e6-87e3-dd5caaf9174f.png">
