### PR TITLE
Replace #disqus_thread by #comments

### DIFF
--- a/source/_layouts/post.latte
+++ b/source/_layouts/post.latte
@@ -21,7 +21,7 @@
             </div>
         </div>
 
-        <div class="container">
+        <div id="comments" class="container">
             {include "disqusComments", 'post' => $post}
         </div>
 

--- a/source/_snippets/post/postMetadataLine.latte
+++ b/source/_snippets/post/postMetadataLine.latte
@@ -19,7 +19,7 @@
 
     <div class="col-md-3">
         <em class="fa fa-fw fa-comments"></em>
-        <a href="{$siteUrl}/{$post['relativeUrl']}/#disqus_thread">X</a>
+        <a href="{$siteUrl}/{$post['relativeUrl']}/#comments">X</a>
         {="post.comment_count"|translate: $post['lang'] ?? 'cs'}
     </div>
 

--- a/source/blog.latte
+++ b/source/blog.latte
@@ -51,7 +51,7 @@ id: blog
 
         <div class="col-md-4">
             <em class="fa fa-fw fa-comments"></em>
-            <a href="{$siteUrl}/{$post['relativeUrl']}/#disqus_thread">X</a>
+            <a href="{$siteUrl}/{$post['relativeUrl']}/#comments">X</a>
             {="post.comment_count"|translate: $post['lang'] ?? 'cs'}
         </div>
     </div>

--- a/source/rss.xml.latte
+++ b/source/rss.xml.latte
@@ -23,7 +23,7 @@
                 <guid isPermaLink="false">{$siteUrl}/blog/{$post['relativeUrl']}</guid>
                 <dc:creator><![CDATA[ {$authors[$post['author']]['name']} ]]></dc:creator>
                 <pubDate>{$post->getDateInFormat('r')}</pubDate>
-                <comments>{$siteUrl}/blog/{$post['relativeUrl']}#disqus_thread</comments>
+                <comments>{$siteUrl}/blog/{$post['relativeUrl']}#comments</comments>
             </item>
         {/foreach}
     </channel>


### PR DESCRIPTION
This is very subjective, but the use of `#disqus_thread` feels wrong to me because using Disqus is something circumstantial. You may replace Disqus by something else in the future. Using `#comments` seems future-proof.