### PR TITLE
Mentors page: Fix page id

### DIFF
--- a/source/_snippets/index/menu.latte
+++ b/source/_snippets/index/menu.latte
@@ -9,7 +9,7 @@
                     <em class="fa fa-book fa-fw"></em>
                     Blog
                 </a>
-                <a href="/mentori" n:class="(isset($id) && $id === mentors) ? active">
+                <a href="/mentori" n:class="(isset($id) && $id === mentori) ? active">
                     <em class="fa fa-handshake-o fa-fw"></em>
                     Mentoři
                 </a>

--- a/source/mentori.latte
+++ b/source/mentori.latte
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Najdi si svého mentora"
-id: mentors
+id: mentori
 ---
 
 {block content}


### PR DESCRIPTION
Aktuálně nefunguje "Upravit" tlačítko, jelikož se někde používalo id `mentors` a jinde `mentori`. Sjednotil jsem to na `mentori` dle latte soubor.