### PR TITLE
https related Disqus comment migration

### DIFF
--- a/source/_config/config.neon
+++ b/source/_config/config.neon
@@ -1,5 +1,5 @@
 pageTitle: "Děláš v PHP? Jsi jedním z nás"
-siteUrl: "http://pehapkari.cz"
+siteUrl: "https://pehapkari.cz"
 githubEditUrlStart: "https://github.com/pehapkari/pehapkari.cz/edit/master/source/"
 githubShowUrlStart: "https://github.com/pehapkari/pehapkari.cz/tree/master/"
 

--- a/source/_data/rewards.neon
+++ b/source/_data/rewards.neon
@@ -42,7 +42,8 @@ rewards:
         count: 5
         image: "slonik.jpg"
         value_in_points: 7
-        winners: []
+        winners:
+            @kbarborak: https://github.com/pehapkari/pehapkari.cz/pull/172
     5:
         title: "Web Security 2016"
         product_link: "https://www.phparch.com/books/web-security-2016/"


### PR DESCRIPTION
Comments are off for old "http" articles, because Disqus works for specific url by default.
Link migration started via Disqus via CVS map.

![migration](https://cloud.githubusercontent.com/assets/924196/21955041/88cecab8-da62-11e6-9b19-80cf286c2a8c.png)
