### PR TITLE
Implemented tags for blog posts

### DIFF
--- a/source/_data/tagList.neon
+++ b/source/_data/tagList.neon
@@ -1,0 +1,11 @@
+tagList:
+    nette:
+        name: Nette Framework
+    symfony:
+        name: Symfony
+    git:
+        name: Git
+    testing:
+        name: Testování
+    blog:
+        name: Blog

--- a/source/_layouts/post.latte
+++ b/source/_layouts/post.latte
@@ -7,6 +7,7 @@
 
             <div class="row text-center">
                 <div class="col-md-12">
+                    {include "tags", "post" => $post}
                     {include "postMetadataLine", "post" => $post}
                     <div n:ifset="$post['reviewed_by']" id="reviewed_by">
                         <p>{="post.reviewed_by"|translate: $post['lang'] ?? $lang}:

--- a/source/_posts/2017/2017-01-05-symfony-console-from-scratch.md
+++ b/source/_posts/2017/2017-01-05-symfony-console-from-scratch.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Symfony Console from the Scratch"
 perex: "Symfony Console is the one package you will probably use to build a PHP CLI app. It's of one the easiest Symfony components. Why? You <strong>only create Application class, add your Command class and you are ready to go</strong>."
+tags: [symfony]
 author: 1
 series: 1 
 tested: true

--- a/source/_posts/2017/2017-01-12-why-articles-with-code-examples-should-be-CI-tested.md
+++ b/source/_posts/2017/2017-01-12-why-articles-with-code-examples-should-be-CI-tested.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Why articles with code examples should be CI tested"
 perex: "I know many great articles that go right to the point. I use their code examples and they work. But when I recommend these articles to people I mentor, I realize the articles are already 2 years old and their code samples probably do not work any more. From hero to zero. Today I will show you how to keep them alive lot longer with a minimal effort."
+tags: [blog, testing]
 author: 1
 lang: en
 reviewed_by: [5]

--- a/source/_posts/2017/2017-01-15-jak-funguje-dependency-injection-v-symfony-a-v-nette.md
+++ b/source/_posts/2017/2017-01-15-jak-funguje-dependency-injection-v-symfony-a-v-nette.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Jak funguje Dependency Injection v Symfony a v Nette"
 perex: "V tomto článku si ukážeme základy Dependency Injection &ndash; jaký je rozdíl mezi Nette presenterem a Symfony controllerem. A jak přenést trochu chování Nette do Symfony."
+tags: [nette, symfony]
 author: 10
 ---
 

--- a/source/_posts/2017/2017-01-23-inteligentni-debug-mode-v-nette.md
+++ b/source/_posts/2017/2017-01-23-inteligentni-debug-mode-v-nette.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Inteligentní debug mode v Nette"
 perex: "Jak se poprat se zapínáním debug módu při vývoji a jeho vypnutím na produkci? A co debug mód v konzoli? Pojďme se podívat, jak to řešit lépe."
+tags: [nette]
 author: 12
 reviewed_by: [1]
 ---

--- a/source/_posts/2017/2017-01-26-jak-zaregistrovat-nette-komponentu-jako-posluchace-udalosti.md
+++ b/source/_posts/2017/2017-01-26-jak-zaregistrovat-nette-komponentu-jako-posluchace-udalosti.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Jak zaregistrovat Nette komponentu jako posluchače událostí"
 perex: "Dnes si povíme o tom, jak přimět Nette <strong>komponenty poslouchat na události</strong>, které nám vyvolává aplikace a umožnit jim se podle toho zachovat."
+tags: [nette]
 author: 11
 tested: true
 test_slug: ListeningNetteComponents

--- a/source/_posts/2017/2017-01-30-konfiguracni-objekty-v-nette.md
+++ b/source/_posts/2017/2017-01-30-konfiguracni-objekty-v-nette.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Konfigurační objekty v Nette"
 perex: "Jak se poprat s předáním konfigurace službě z config.neon? A jak k tomu využít Nette DI?"
+tags: [nette]
 author: 12
 tested: true
 test_slug: NetteConfigObjects

--- a/source/_posts/2017/2017-02-06-how-to-rehash-legacy-passwords-in-symfony.md
+++ b/source/_posts/2017/2017-02-06-how-to-rehash-legacy-passwords-in-symfony.md
@@ -2,6 +2,7 @@
 layout: post
 title: "How to rehash legacy passwords in Symfony"
 perex: "You need to import users from an old project, but but don't want to bother them with resetting their passwords just because you want to use bcrypt. Fortunately, there is a solution."
+tags: [symfony]
 author: 14
 lang: en
 reviwed_by: [1, 5]

--- a/source/_posts/2017/2017-02-09-jak-na-testovani-pomoci-codeception.md
+++ b/source/_posts/2017/2017-02-09-jak-na-testovani-pomoci-codeception.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Jak na akceptační testovaní pomocí Codeception"
 perex: "Jak automaticky testovat celé stránky a simulovat chování uživatele na webu pomocí Codeception"
+tags: [testing]
 author: 15
 ---
 

--- a/source/_snippets/post/tags.latte
+++ b/source/_snippets/post/tags.latte
@@ -1,0 +1,8 @@
+<div class="tags" n:if="!empty($post['tags'])">
+    {foreach $post['tags'] as $tag}
+        <span class="tag">
+            <i class="fa fa-tag" aria-hidden="true"></i>
+            {$tagList[$tag]['name']}
+        </span>
+    {/foreach}
+</div>

--- a/source/assets/css/style.css
+++ b/source/assets/css/style.css
@@ -240,6 +240,14 @@ h1, h2, .h2, h3 {
     line-height: 2.5em;
 }
 
+.tags .tag {
+    margin: 0 3px;
+    padding: 4px 7px;
+    border-radius: 7px;
+    background: #ddd;
+    font-size: 13px;
+}
+
 #article {
     padding-top: 1em;
 }

--- a/source/blog.latte
+++ b/source/blog.latte
@@ -33,6 +33,7 @@ id: blog
 
                 <div class="row">
                     <div class="col-md-12">
+                        {include "tags", "post" => $post}
                         {include "postMetadataLine", "post" => $post}
                     </div>
                 </div>


### PR DESCRIPTION
Here's an idea of tags for articles, as suggested in #214. What do you think?

in blog tab:
![list](https://cloud.githubusercontent.com/assets/144181/22678033/66fb9428-ecf7-11e6-9127-5cbfb8560b79.png)
in article detail:
![article](https://cloud.githubusercontent.com/assets/144181/22678036/6a48f8d2-ecf7-11e6-85ec-02b2a9ed16d7.png)

Yes, visual styling is just a proof of concept, feel free to tweak it more.

TODO:

- [ ] L10N