### PR TITLE
[blog] typo

### DIFF
--- a/source/_posts/2017/2017-02-06-how-to-rehash-legacy-passwords-in-symfony.md
+++ b/source/_posts/2017/2017-02-06-how-to-rehash-legacy-passwords-in-symfony.md
@@ -185,7 +185,7 @@ final class PasswordUpdateManager implements EventSubscriberInterface
     public static function getSubscribedEvents() : array
     {
         return [
-            'app._user_legacy' => 'storePasswordForRehash',
+            'app.legacy_user' => 'storePasswordForRehash',
             SecurityEvents::INTERACTIVE_LOGIN => 'rehashPassword',
         ];
     }


### PR DESCRIPTION
Pointed out in comments by Jozef Koščák: https://pehapkari.cz/blog/2017/02/06/how-to-rehash-legacy-passwords-in-symfony/#comment-3167159096

Maybe it would be good idea to move the event name to constant, same way as `SecurityEvents::INTERACTIVE_LOGIN`?