### PR TITLE
prism.css: set default style to empty code highlights

### DIFF
--- a/source/assets/prism/prism.css
+++ b/source/assets/prism/prism.css
@@ -29,6 +29,7 @@ cyan      #2aa198
 green     #859900
 */
 
+pre > code,
 code[class*="language-"],
 pre[class*="language-"] {
 	color: #657b83; /* base00 */


### PR DESCRIPTION
This will improve those ugly empty code snippets.


    ```
    some code
    ```
