### PR TITLE
[CodingStandard] drop annoying rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/node_modules
 /output
 /vendor
 /node_modules

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/intl": "^3.2",
         "symfony/validator": "^3.2",
 
-        "phpstan/phpstan": "dev-master",
+        "phpstan/phpstan": "^0.7",
         "phpunit/phpunit": "^6.0",
         "squizlabs/php_codesniffer": "3.0.0RC4 as 2.8.1",
         "symplify/easy-coding-standard": "v2.0.0-RC2",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "squizlabs/php_codesniffer": "3.0.0RC4 as 2.8.1",
         "symplify/easy-coding-standard": "v2.0.0-RC2",
         "symplify/coding-standard": "v2.0.0-RC2",
-        "object-calisthenics/phpcs-calisthenics-rules": "v3.0.0-RC3",
         "slevomat/coding-standard": "^2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "squizlabs/php_codesniffer": "3.0.0RC4 as 2.8.1",
         "symplify/easy-coding-standard": "v2.0.0-RC2",
         "symplify/coding-standard": "v2.0.0-RC2",
-        "slevomat/coding-standard": "^2.1"
+        "slevomat/coding-standard": "^2.3"
     },
     "autoload": {
         "psr-4": {

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -53,29 +53,10 @@ checkers:
         nestingLevel: 3
         absoluteNestingLevel: 6
     - PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff
-    - ObjectCalisthenics\Sniffs\Metrics\MaxNestingLevelSniff
-    ObjectCalisthenics\Sniffs\Metrics\MethodPerClassLimitSniff:
-        maxCount: 16 # 10 by default
-    - ObjectCalisthenics\Sniffs\Metrics\PropertyPerClassLimitSniff
-    - ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff
-    - ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff
-    ObjectCalisthenics\Sniffs\CodeAnalysis\OneObjectOperatorPerLineSniff:
-        variablesHoldingAFluentInterface:
-            - $containerBuilder
-            - $container
-            - $kernel
-            - $rootNode
-            - $requestMock
-            - $entityManagerMock
-        methodsStartingAFluentInterface:
-            - buildViolation
-            - getValidator
-            - addText
 
     # Naming Conventions
     - PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\UpperCaseConstantNameSniff
     - PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff
-    - ObjectCalisthenics\Sniffs\NamingConventions\ElementNameMinimalLengthSniff
 
     # PHP
     - PhpCsFixer\Fixer\PhpTag\FullOpeningTagFixer

--- a/source/_posts/2017/2017-05-01-symfony-a-wedos-multihosting.md
+++ b/source/_posts/2017/2017-05-01-symfony-a-wedos-multihosting.md
@@ -26,7 +26,7 @@ Jedná se o klasický [NoLimit webhosting](https://hosting.wedos.com/cs/webhosti
             * .
             * web
                 * app.php
-                .htaccess            
+                .htaccess
     * subdom
     * .htaccess
 ```


### PR DESCRIPTION
Based on https://github.com/pehapkari/pehapkari.cz/issues/287

I realized, [object-calisthenics](https://github.com/object-calisthenics/phpcs-calisthenics-rules) might be too strict architecture pattern. And I don't want to make contributting to community blog pain, just because of them.

Sorry about that @jkuchar, that was not intention of this.

