### PR TITLE
apostrofy kolem kódu pro Google Analytics

### DIFF
--- a/source/_snippets/googleAnalytics.twig
+++ b/source/_snippets/googleAnalytics.twig
@@ -5,5 +5,5 @@
     function gtag(){ dataLayer.push(arguments); }
     gtag('js', new Date());
 
-    gtag('config', {{ google_analytics_tracking_id }});
+    gtag('config', '{{ google_analytics_tracking_id }}');
 </script>


### PR DESCRIPTION
bez apostrofů se renderuje takto a nefunguje:
gtag('config', UA-89860072-1);

ReferenceError: UA is not defined