### PR TITLE
Ignore AccessDeniedException in sentry - it is no real error

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -5,3 +5,4 @@ sentry:
         excluded_exceptions:
             - 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException'
             - 'Symfony\Component\Routing\Exception\ResourceNotFoundException'
+            - 'Symfony\Component\Security\Core\Exception\AccessDeniedException'


### PR DESCRIPTION
It creates error reports in sentry - false positive imho and developer should not be notified when this exception happens at 403 response is expected and correct.