### PR TITLE
Fixes typos

### DIFF
--- a/packages/Registration/src/Form/TrainingRegistrationFormType.php
+++ b/packages/Registration/src/Form/TrainingRegistrationFormType.php
@@ -30,7 +30,7 @@ final class TrainingRegistrationFormType extends AbstractType
         ]);
 
         $formBuilder->add('email', TextType::class, [
-            'label' => 'Tvůj email',
+            'label' => 'Tvůj e-mail',
             'required' => true,
         ]);
 

--- a/statie/source/_posts/2017/2017-03-02-php-u-nas-ceka-rok-expanze.md
+++ b/statie/source/_posts/2017/2017-03-02-php-u-nas-ceka-rok-expanze.md
@@ -26,7 +26,7 @@ Unikla ti nějaká akce, na které jsi chtěl být? **Subscribni se k [akcím na
 
 ## Dohodli jsem se na společném místu online
 
-Ještě minulý rok nebylo moc jasné, kde se ptát na různé věci kolem PHP. Nette fórum? Symfony gitter? Jak psát web? Email? Twitter?
+Ještě minulý rok nebylo moc jasné, kde se ptát na různé věci kolem PHP. Nette fórum? Symfony gitter? Jak psát web? E-mail? Twitter?
 
 S [Honzou Černým](http://honzacerny.com/) jsme si řekli, že tu schizofrenii změníme a na podzim [jsme spustili společný PHP Slack](http://pehapkari.cz/#slack). Za **4 měsíce běhu jsme vyrostli ze 150 lidí na 650**. Včetně 55 kanálů!
 

--- a/statie/source/_posts/2018/2018-01-24-solid-principy-princip-jedne-odpovednosti.md
+++ b/statie/source/_posts/2018/2018-01-24-solid-principy-princip-jedne-odpovednosti.md
@@ -14,7 +14,7 @@ Video (1:26)
 
 [![Video na Youtube](/assets/images/posts/2018/solid-1/youtube.png)](http://www.youtube.com/watch?v=GeezKhlAV-w)
 
-Mám zde například třídu ```Person```, která se uchovává data osoby, ale také validuje email. Což je právě ta věc, která by dle tohohle principu měla být samostatně.
+Mám zde například třídu ```Person```, která se uchovává data osoby, ale také validuje e-mail. Což je právě ta věc, která by dle tohohle principu měla být samostatně.
 
 ```php
 <?php
@@ -57,9 +57,9 @@ class Person
 }
 ```
 
-Řešením zde může být to, že se bude požadovat konkrétní typ pro email.
+Řešením zde může být to, že se bude požadovat konkrétní typ pro e-mail.
 
-Vytvoříme třídu ```Email```, která bude ihned při inicializaci validovat vstup. V konstruktoru proběhne validace. Následně ve třídě ```Person``` můžeme vyžadovat typ Email a budeme mít jistotu, že email vždy prošel validací.
+Vytvoříme třídu ```Email```, která bude ihned při inicializaci validovat vstup. V konstruktoru proběhne validace. Následně ve třídě ```Person``` můžeme vyžadovat typ ```Email``` a budeme mít jistotu, že e-mail vždy prošel validací.
 
 ```php
 <?php


### PR DESCRIPTION
According to UJČ (http://prirucka.ujc.cas.cz/?slovo=e-mail) in czech the proper form of the word is e-mail, not email.