### PR TITLE
Hotfix links in section "Continue reading"

### DIFF
--- a/src/Twig/Extension/StatieFiltersExtension.php
+++ b/src/Twig/Extension/StatieFiltersExtension.php
@@ -47,7 +47,7 @@ final class StatieFiltersExtension extends AbstractExtension
                     $this->ensureArgumentIsGeneratorFile($generatorFile);
 
                     /** @var AbstractGeneratorFile $generatorFile */
-                    return $generatorFile->getRelativeUrl();
+                    return '/' . $generatorFile->getRelativeUrl();
                 }
             ),
         ];


### PR DESCRIPTION
If You take a look to section "Continue reading" eg. in https://pehapkari.cz/blog/2018/02/28/domain-driven-design-repository , You'll see that links don't work

I don't know whether this is a proper solution, but it works 