### PR TITLE
Disallow trailing slash on blog post

### DIFF
--- a/packages/blog/src/Controller/PostController.php
+++ b/packages/blog/src/Controller/PostController.php
@@ -24,7 +24,7 @@ final class PostController extends AbstractController
     }
 
     /**
-     * @Route(path="blog/{postSlug}", name="post", requirements={"postSlug":".+"})
+     * @Route(path="blog/{postSlug}", name="post", requirements={"postSlug":".+[^\/]"})
      */
     public function __invoke(string $postSlug): Response
     {


### PR DESCRIPTION
The post slug can contain slash (e.g. slug "/blog/2019/12/23/how-we-upgraded-pehapkari-cz-from-symfony-4-to-5-in-25-days") but when trailing slash is allowed, the route is not catched and the trailing slash is not removed. I edited the requirements to allow slash everywhere but at the end.

Fixes #302