### PR TITLE
Fix newsletter archive link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -258,7 +258,7 @@
                 </form>
                 <p class="mt-3 text-sm leading-5 text-indigo-200">
                     archív najdeš na
-                    <a href="https://tinyletter.com/pehapkari" class="text-white font-medium underline">
+                    <a href="https://tinyletter.com/pehapkari/archive" class="text-white font-medium underline">
                         TinyLetter
                     </a>
                 </p>


### PR DESCRIPTION
link to archive at newsletter form now redirect direct to TinyLetter Archive 